### PR TITLE
タスク完了機能の実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,9 +2,9 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
   def index
     @show = params[:show]
-    if @show == "all" then
+    if @show == "all"
       @tasks = Task.all
-    elsif @show == "completed" then
+    elsif @show == "completed"
       @tasks = Task.where(completed: 1)
     else
       @tasks = Task.where(completed: 0)
@@ -73,7 +73,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :descriptionm, :image, :column, :completed)
+    params.require(:task).permit(:name, :descriptionm, :image, :completed)
   end
 
   def set_task

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,12 +1,20 @@
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
   def index
+    @show = params[:show]
+    if @show == "all" then
+      @tasks = Task.all
+    elsif @show == "completed" then
+      @tasks = Task.where(completed: 1)
+    else
+      @tasks = Task.where(completed: 0)
+    end
     @q = current_user.tasks.ransack(params[:q])
-    @tasks = @q.result(distinct: true).page(params[:page])
+    @tasks_page = @q.result(distinct: true).page(params[:page])
 
     respond_to do |format|
       format.html
-      format.csv { send_data @tasks.generate_csv, filename: "tasks-#{Time.zone.now.strftime('%Y%m%d%S')}.csv"}
+      format.csv { send_data @tasks_page.generate_csv, filename: "tasks-#{Time.zone.now.strftime('%Y%m%d%S')}.csv"}
     end
   end
 
@@ -65,7 +73,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :descriptionm, :image)
+    params.require(:task).permit(:name, :descriptionm, :image, :column, :completed)
   end
 
   def set_task

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -13,4 +13,7 @@
   .form_group
     = f.label :image
     = f.file_field :image, class: 'form-control'
+  .form-group
+    = f.label :completed
+    = f.select :completed, [['未完了',0],['完了',1]], {}, class: 'form-control', id: 'task_completed'
   =f.submit nil, class:"btn btn-primary"

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -19,8 +19,8 @@ li = link_to "新規作成",new_task_path,class:"btn btn-primary"
   = page_entries_info @tasks_page
 .mb3
   = link_to 'すべて', tasks_path(:show=>'all'), class: 'btn btn-outline-primary'
-  = link_to '完了', tasks_path(:show=>'completed'), class: 'btn btn-outline-success'
-  = link_to '未完了', tasks_path, class: 'btn btn-outline-dark'
+  = link_to '完了', tasks_path(:show=>'completed'), class: 'btn btn-outline-primary'
+  = link_to '未完了', tasks_path, class: 'btn btn-outline-primary'
 
 table.table.table-hover
   thead.thead-default

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -13,9 +13,14 @@ h1 タスク一覧
     = f.submit class: 'btn btn-outline-primary'
 
 li = link_to "新規作成",new_task_path,class:"btn btn-primary"
+
 .mb3
-  = paginate @tasks
-  = page_entries_info @tasks
+  = paginate @tasks_page
+  = page_entries_info @tasks_page
+.mb3
+  = link_to 'すべて', tasks_path(:show=>'all'), class: 'btn btn-outline-primary'
+  = link_to '完了', tasks_path(:show=>'completed'), class: 'btn btn-outline-success'
+  = link_to '未完了', tasks_path, class: 'btn btn-outline-dark'
 
 table.table.table-hover
   thead.thead-default

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -16,5 +16,8 @@ h1 タスクの新規作成
     = f.label :description
     = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
   = f.submit '確認', class: 'btn btn-primary'
+  .form-group
+    = f.hidden_field :completed,:value => 0, id: 'task_completed'
+  = f.submit nil, class: 'btn btn-primary'
 
 = render partial: "form", locals: { task: @task }

--- a/db/migrate/20200325103436_add_completed_to_tasks.rb
+++ b/db/migrate/20200325103436_add_completed_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddCompletedToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :completed, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_221930) do
+ActiveRecord::Schema.define(version: 2020_03_25_103436) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2020_03_24_221930) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.integer "completed"
     t.index ["name"], name: "index_tasks_on_name", unique: true
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end


### PR DESCRIPTION
## なぜ変更するのか
タスク完了機能を実装
## 技術的変更点
タスク切り替えボタン
それぞれ違うurlを指定することで絞ることができる。
最初のページは未完了タスクのページ
<img width="1162" alt="スクリーンショット 2020-03-26 1 27 38" src="https://user-images.githubusercontent.com/51541610/77561315-e40e1500-6f01-11ea-9318-8533fcbb2322.png">
<img width="1218" alt="スクリーンショット 2020-03-26 1 27 55" src="https://user-images.githubusercontent.com/51541610/77561359-f38d5e00-6f01-11ea-8d60-d947ae99b3ea.png">
<img width="1174" alt="スクリーンショット 2020-03-26 1 28 11" src="https://user-images.githubusercontent.com/51541610/77561379-f720e500-6f01-11ea-8d36-6a97af8b18c6.png">

タスクの編集ページにてタスクを完了に変更できる
<img width="1235" alt="スクリーンショット 2020-03-26 1 33 15" src="https://user-images.githubusercontent.com/51541610/77561644-5121aa80-6f02-11ea-9a4c-85702daaae85.png">
## 期待する動作
## レビューして欲しいこと
## 補足説明 or 関連URL
まだ動作が完璧でないとこが何個かある。
例えば画像をつけてupするとエラーページになるが投稿はできている。等